### PR TITLE
chore: remove known_hosts dependency in push_codeberg.yml

### DIFF
--- a/.github/workflows/push_codeberg.yml
+++ b/.github/workflows/push_codeberg.yml
@@ -12,7 +12,6 @@ jobs:
           mkdir -p ~/.ssh
           echo "${{ secrets.GIT_SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
-          echo "${{ secrets.GIT_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
-          git config --global core.sshCommand 'ssh -i ~/.ssh/id_rsa -o IdentitiesOnly=yes -o UserKnownHostsFile=~/.ssh/known_hosts'
+          git config --global core.sshCommand 'ssh -i ~/.ssh/id_rsa -o IdentitiesOnly=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
           git remote add mirror ssh://git@codeberg.org/LocalCharts/forest.git
           git push --tags --force --prune mirror 'refs/remotes/origin/*:refs/heads/*'


### PR DESCRIPTION
Hi,

I’m not sure what your project does but I found it randomly in GitHub search looking for idea how to sync my repo remotely to Codeberg using SSH, I really liked the clean and concise approach in your `push_codeberg.yml` so I copied it to my project.

As part of the adaptation I was able to remove the dependency on the known host SSH repository secret `GIT_SSH_KNOWN_HOSTS ` and I thought you might be interested as this could prevent having to update in the future should the signatures change.